### PR TITLE
Add availability management endpoints for caregivers

### DIFF
--- a/backend/HealthcareBooking.Api/Controller/AvailabilityController.cs
+++ b/backend/HealthcareBooking.Api/Controller/AvailabilityController.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using HealthcareBooking.Api.Entities;
+using HealthcareBooking.Api.Service;
+using HealthcareBooking.Api.Dto;
+using System.Security.Claims;
+
+namespace HealthcareBooking.Api.Controllers;
+
+[ApiController]
+[Route("v1/api/availability")]
+[Authorize]
+public class AvailabilityController : ControllerBase
+{
+    private readonly AvailabilityService _availabilityService;
+
+    public AvailabilityController(AvailabilityService availabilityService)
+    {
+        _availabilityService = availabilityService;
+    }
+
+    // POST /v1/api/availability
+    // Creates an availability slot for the authenticated caregiver
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateAvailabilityDto dto)
+    {
+        var user = GetAuthenticatedUser();
+
+        try
+        {
+            var availability = await _availabilityService.CreateAvailabilityAsync(
+                user,
+                dto.Start,
+                dto.End);
+
+            return Created(string.Empty, availability);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+    // GET /v1/api/availability/me
+    // Returns availability for the authenticated caregiver
+    [HttpGet("me")]
+    public IActionResult GetMyAvailability()
+    {
+        var user = GetAuthenticatedUser();
+
+        if (user.Role != UserRole.Caregiver)
+            return Forbid();
+
+        return Ok(user.Availabilities);
+    }
+
+    // Helpers
+    private User GetAuthenticatedUser()
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var roleClaim = User.FindFirst(ClaimTypes.Role)?.Value;
+
+        if (!int.TryParse(userIdClaim, out var userId))
+            throw new UnauthorizedAccessException();
+
+        var role = Enum.Parse<UserRole>(roleClaim!);
+
+        return new User
+        {
+            Id = userId,
+            Role = role
+        };
+    }
+}

--- a/backend/HealthcareBooking.Api/Dto/CreateAvailabilityDto.cs
+++ b/backend/HealthcareBooking.Api/Dto/CreateAvailabilityDto.cs
@@ -1,0 +1,7 @@
+namespace HealthcareBooking.Api.Dto;
+
+public class CreateAvailabilityDto
+{
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
+}

--- a/backend/HealthcareBooking.Api/Program.cs
+++ b/backend/HealthcareBooking.Api/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddScoped<PasswordService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<JwtTokenService>();
+builder.Services.AddScoped<AvailabilityService>();
 
 // Authentication / Authorization
 builder.Services

--- a/backend/HealthcareBooking.Api/Service/AvailabilityService.cs
+++ b/backend/HealthcareBooking.Api/Service/AvailabilityService.cs
@@ -1,0 +1,40 @@
+using HealthcareBooking.Api.Data;
+using HealthcareBooking.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HealthcareBooking.Api.Service;
+
+public class AvailabilityService
+{
+    private readonly AppDbContext _context;
+
+    public AvailabilityService(AppDbContext context) { _context = context; }
+
+    public async Task<Availability>
+    CreateAvailabilityAsync(User caregiver, DateTime start, DateTime end)
+    {
+        // Role check
+        if (caregiver.Role != UserRole.Caregiver)
+            throw new InvalidOperationException(
+                "Only caregivers can create availability.");
+
+        // Time validation
+        if (start >= end)
+            throw new InvalidOperationException(
+                "Start time must be before end time.");
+
+        var availability =
+            new Availability
+            {
+                CaregiverId = caregiver.Id,
+                Start =
+                                   DateTime.SpecifyKind(start, DateTimeKind.Utc),
+                End = DateTime.SpecifyKind(end, DateTimeKind.Utc)
+            };
+
+        _context.Availabilities.Add(availability);
+        await _context.SaveChangesAsync();
+
+        return availability;
+    }
+}

--- a/backend/HealthcareBooking.Tests/AvailabilityServiceTests.cs
+++ b/backend/HealthcareBooking.Tests/AvailabilityServiceTests.cs
@@ -1,0 +1,94 @@
+using HealthcareBooking.Api.Data;
+using HealthcareBooking.Api.Entities;
+using HealthcareBooking.Api.Service;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+public class AvailabilityServiceTests
+{
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static AvailabilityService CreateService(AppDbContext context)
+    {
+        return new AvailabilityService(context);
+    }
+
+    [Fact]
+    public async Task CreateAvailability_Caregiver_Succeeds()
+    {
+        // Arrange
+        var context = CreateDbContext();
+        var service = CreateService(context);
+
+        var caregiver = new User
+        {
+            Id = 1,
+            Role = UserRole.Caregiver
+        };
+
+        var start = DateTime.UtcNow.AddHours(1);
+        var end = DateTime.UtcNow.AddHours(2);
+
+        // Act
+        var availability = await service.CreateAvailabilityAsync(
+            caregiver,
+            start,
+            end);
+
+        // Assert
+        Assert.NotNull(availability);
+        Assert.Equal(caregiver.Id, availability.CaregiverId);
+        Assert.Equal(start, availability.Start);
+        Assert.Equal(end, availability.End);
+        Assert.Single(context.Availabilities);
+    }
+
+    [Fact]
+    public async Task CreateAvailability_Patient_Throws()
+    {
+        // Arrange
+        var context = CreateDbContext();
+        var service = CreateService(context);
+
+        var patient = new User
+        {
+            Id = 2,
+            Role = UserRole.Patient
+        };
+
+        var start = DateTime.UtcNow.AddHours(1);
+        var end = DateTime.UtcNow.AddHours(2);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CreateAvailabilityAsync(patient, start, end));
+    }
+
+    [Fact]
+    public async Task CreateAvailability_StartAfterEnd_Throws()
+    {
+        // Arrange
+        var context = CreateDbContext();
+        var service = CreateService(context);
+
+        var caregiver = new User
+        {
+            Id = 3,
+            Role = UserRole.Caregiver
+        };
+
+        var start = DateTime.UtcNow.AddHours(2);
+        var end = DateTime.UtcNow.AddHours(1);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CreateAvailabilityAsync(caregiver, start, end));
+    }
+}


### PR DESCRIPTION
This PR introduces API support for caregivers to manage their availability.

### Changes included:
- Added Availability domain entity linked to caregiver users
- Implemented POST /availability and GET /availability/me endpoints
- Enforced caregiver-only access for availability management
- Added validation to ensure start time is before end time
- Normalized availability timestamps to UTC before persistence
- Added unit tests for AvailabilityService covering role and time validation

Closes #16 