### PR TITLE
Allow patients to fetch available appointment slots

### DIFF
--- a/backend/HealthcareBooking.Api/Controller/AppointmentsController.cs
+++ b/backend/HealthcareBooking.Api/Controller/AppointmentsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using HealthcareBooking.Api.Service;
+using HealthcareBooking.Api.Entities;
+
+namespace HealthcareBooking.Api.Controllers;
+
+[ApiController]
+[Route("v1/api/appointments")]
+[Authorize]
+public class AppointmentsController : ControllerBase
+{
+    private readonly AvailableAppointmentService _availableAppointmentService;
+
+    public AppointmentsController(
+        AvailableAppointmentService availableAppointmentService)
+    {
+        _availableAppointmentService = availableAppointmentService;
+    }
+
+    // GET /v1/api/appointments/available?caregiverId=5
+    // Allows patients to fetch available appointment slots
+    [HttpGet("available")]
+    public async Task<IActionResult> GetAvailable(
+        [FromQuery] int caregiverId)
+    {
+        if (caregiverId <= 0)
+            return BadRequest("caregiverId is required");
+
+        var slots = await _availableAppointmentService
+            .GetAvailableSlotsAsync(caregiverId);
+
+        return Ok(slots);
+    }
+}

--- a/backend/HealthcareBooking.Api/Entities/AvailableSlot.cs
+++ b/backend/HealthcareBooking.Api/Entities/AvailableSlot.cs
@@ -1,0 +1,8 @@
+namespace HealthcareBooking.Api.Entities;
+
+public class AvailableSlot
+{
+    public int CaregiverId { get; set; }
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
+}

--- a/backend/HealthcareBooking.Api/Program.cs
+++ b/backend/HealthcareBooking.Api/Program.cs
@@ -29,6 +29,7 @@ builder.Services.AddScoped<PasswordService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddScoped<AvailabilityService>();
+builder.Services.AddScoped<AvailableAppointmentService>();
 
 // Authentication / Authorization
 builder.Services

--- a/backend/HealthcareBooking.Api/Service/AvailableAppointmentService.cs
+++ b/backend/HealthcareBooking.Api/Service/AvailableAppointmentService.cs
@@ -1,0 +1,106 @@
+using HealthcareBooking.Api.Data;
+using HealthcareBooking.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace HealthcareBooking.Api.Service;
+
+public class AvailableAppointmentService
+{
+    private readonly AppDbContext _context;
+
+    public AvailableAppointmentService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    // Returns future appointment slots for a caregiver.
+    // Slots are calculated by subtracting booked appointments from availability.
+    public async Task<IReadOnlyList<AvailableSlot>> GetAvailableSlotsAsync(int caregiverId)
+    {
+        // Capture the current time once to keep comparisons consistent
+        var now = DateTime.UtcNow;
+
+        // Load future availability windows for the caregiver
+        var availabilities = await _context.Availabilities
+            .Where(a =>
+                a.CaregiverId == caregiverId &&
+                a.End > now)
+            .OrderBy(a => a.Start)
+            .ToListAsync();
+
+        // Load future, booked appointments for the caregiver
+        var appointments = await _context.Appointments
+            .Where(a =>
+                a.CaregiverId == caregiverId &&
+                a.Status == AppointmentStatus.Booked &&
+                a.End > now)
+            .OrderBy(a => a.Start)
+            .ToListAsync();
+
+        var availableSlots = new List<AvailableSlot>();
+
+        foreach (var availability in availabilities)
+        {
+            // Ensure we never return a slot starting in the past
+            var slotStart = availability.Start < now
+                ? now
+                : availability.Start;
+
+            var slotEnd = availability.End;
+
+            // Find appointments that overlap this availability window
+            var overlappingAppointments = appointments
+                .Where(a =>
+                    a.Start < slotEnd &&
+                    a.End > slotStart)
+                .ToList();
+
+            foreach (var appointment in overlappingAppointments)
+            {
+                // Add free time before the appointment, if any
+                TryAddSlot(
+                    availableSlots,
+                    caregiverId,
+                    slotStart,
+                    appointment.Start);
+
+                // Move the pointer past the appointment
+                slotStart = appointment.End < now
+                    ? now
+                    : appointment.End;
+            }
+
+            // Add remaining free time after the last appointment
+            TryAddSlot(
+                availableSlots,
+                caregiverId,
+                slotStart,
+                slotEnd);
+        }
+
+        return availableSlots;
+    }
+
+    // Adds a slot only if it represents a real, usable time range.
+    // Prevents zero-length or microsecond slots caused by time precision.
+    private static void TryAddSlot(
+        List<AvailableSlot> slots,
+        int caregiverId,
+        DateTime start,
+        DateTime end)
+    {
+        if (end <= start)
+            return;
+
+        // Ignore extremely short slots that are not meaningful for appointments
+        if (end - start < TimeSpan.FromSeconds(1))
+            return;
+
+        slots.Add(new AvailableSlot
+        {
+            CaregiverId = caregiverId,
+            Start = start,
+            End = end
+        });
+    }
+}

--- a/backend/HealthcareBooking.Tests/AvailableAppointmentServiceTests.cs
+++ b/backend/HealthcareBooking.Tests/AvailableAppointmentServiceTests.cs
@@ -1,0 +1,139 @@
+using HealthcareBooking.Api.Data;
+using HealthcareBooking.Api.Entities;
+using HealthcareBooking.Api.Service;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+public class AvailableAppointmentServiceTests
+{
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+                          .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                          .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static AvailableAppointmentService
+    CreateService(AppDbContext context)
+    {
+        return new AvailableAppointmentService(context);
+    }
+
+    [Fact]
+    public async Task Returns_full_availability_when_no_appointments_exist()
+    {
+        var context = CreateDbContext();
+
+        context.Availabilities.Add(
+            new Availability
+            {
+                CaregiverId = 1,
+                Start = DateTime.UtcNow.AddHours(1),
+                End = DateTime.UtcNow.AddHours(4)
+            });
+
+        await context.SaveChangesAsync();
+
+        var service = CreateService(context);
+
+        var result = await service.GetAvailableSlotsAsync(1);
+
+        Assert.Single(result);
+        Assert.Equal(DateTime.UtcNow.AddHours(1).Hour, result[0].Start.Hour);
+        Assert.Equal(DateTime.UtcNow.AddHours(4).Hour, result[0].End.Hour);
+    }
+
+    [Fact]
+    public async Task Excludes_fully_booked_availability()
+    {
+        var context = CreateDbContext();
+
+        context.Availabilities.Add(
+            new Availability
+            {
+                CaregiverId = 1,
+                Start = DateTime.UtcNow.AddHours(1),
+                End = DateTime.UtcNow.AddHours(3)
+            });
+
+        context.Appointments.Add(new Appointment
+        {
+            CaregiverId = 1,
+            PatientId = 2,
+            Start = DateTime.UtcNow.AddHours(1),
+            End = DateTime.UtcNow.AddHours(3),
+            Status = AppointmentStatus.Booked
+        });
+
+        await context.SaveChangesAsync();
+
+        var service = CreateService(context);
+
+        var result = await service.GetAvailableSlotsAsync(1);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Splits_availability_around_booked_appointment()
+    {
+        var context = CreateDbContext();
+
+        context.Availabilities.Add(
+            new Availability
+            {
+                CaregiverId = 1,
+                Start = DateTime.UtcNow.AddHours(1),
+                End = DateTime.UtcNow.AddHours(4)
+            });
+
+        context.Appointments.Add(new Appointment
+        {
+            CaregiverId = 1,
+            PatientId = 2,
+            Start = DateTime.UtcNow.AddHours(2),
+            End = DateTime.UtcNow.AddHours(3),
+            Status = AppointmentStatus.Booked
+        });
+
+        await context.SaveChangesAsync();
+
+        var service = CreateService(context);
+
+        var result = await service.GetAvailableSlotsAsync(1);
+
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal(DateTime.UtcNow.AddHours(1).Hour, result[0].Start.Hour);
+        Assert.Equal(DateTime.UtcNow.AddHours(2).Hour, result[0].End.Hour);
+
+        Assert.Equal(DateTime.UtcNow.AddHours(3).Hour, result[1].Start.Hour);
+        Assert.Equal(DateTime.UtcNow.AddHours(4).Hour, result[1].End.Hour);
+    }
+
+    [Fact]
+    public async Task Does_not_return_past_time_slots()
+    {
+        var context = CreateDbContext();
+
+        var now = DateTime.UtcNow;
+
+        context.Availabilities.Add(new Availability
+        {
+            CaregiverId = 1,
+            Start = now.AddHours(-2),
+            End = now.AddHours(2)
+        });
+
+        await context.SaveChangesAsync();
+
+        var service = CreateService(context);
+
+        var result = await service.GetAvailableSlotsAsync(1);
+
+        Assert.Single(result);
+        Assert.True(result[0].Start >= now);
+    }
+}


### PR DESCRIPTION
This PR adds support for fetching available appointment slots based on caregiver availability.

### Changes included:
- Implemented AvailableAppointmentService to calculate free slots
- Added GET /appointments/available endpoint
- Ensured only future time slots are returned
- Excluded slots overlapping with booked appointments
- Added unit tests covering edge cases and time boundaries

Closes #17
