### PR TITLE
Appointment booking, rescheduling, and automated service tests

### DIFF
--- a/backend/HealthcareBooking.Api/Controller/AppointmentsController.cs
+++ b/backend/HealthcareBooking.Api/Controller/AppointmentsController.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using HealthcareBooking.Api.Service;
 using HealthcareBooking.Api.Entities;
+using HealthcareBooking.Api.Dto;
+using System.Security.Claims;
 
 namespace HealthcareBooking.Api.Controllers;
 
@@ -11,25 +13,90 @@ namespace HealthcareBooking.Api.Controllers;
 public class AppointmentsController : ControllerBase
 {
     private readonly AvailableAppointmentService _availableAppointmentService;
+    private readonly AppointmentService _appointmentService;
 
     public AppointmentsController(
-        AvailableAppointmentService availableAppointmentService)
+        AvailableAppointmentService availableAppointmentService,
+        AppointmentService appointmentService)
     {
         _availableAppointmentService = availableAppointmentService;
+        _appointmentService = appointmentService;
     }
 
     // GET /v1/api/appointments/available?caregiverId=5
     // Allows patients to fetch available appointment slots
     [HttpGet("available")]
-    public async Task<IActionResult> GetAvailable(
-        [FromQuery] int caregiverId)
+    public async Task<IActionResult> GetAvailable([FromQuery] int caregiverId)
     {
         if (caregiverId <= 0)
             return BadRequest("caregiverId is required");
 
-        var slots = await _availableAppointmentService
-            .GetAvailableSlotsAsync(caregiverId);
+        var slots =
+            await _availableAppointmentService.GetAvailableSlotsAsync(caregiverId);
 
         return Ok(slots);
+    }
+
+    // POST /v1/api/appointments
+    // Allows a patient to book an appointment
+    [HttpPost]
+    [Authorize(Roles = "Patient")]
+    public async Task<IActionResult> Book([FromBody] CreateAppointmentDto dto)
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var roleClaim = User.FindFirst(ClaimTypes.Role)?.Value;
+
+        if (!int.TryParse(userIdClaim, out var userId))
+            return Unauthorized();
+
+        var patient =
+            new User { Id = userId, Role = Enum.Parse<UserRole>(roleClaim!) };
+
+        try
+        {
+            var appointment = await _appointmentService.BookAsync(
+                patient, dto.CaregiverId, dto.Start, dto.End);
+
+            return Created(string.Empty, new AppointmentResponse(
+                                             appointment.Id, appointment.CaregiverId,
+                                             appointment.PatientId, appointment.Start,
+                                             appointment.End, appointment.Status));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { error = ex.Message });
+        }
+    }
+
+    // PATCH /v1/api/appointments/{id}/reschedule
+    // Allows patients to reschedule their appointments
+    [HttpPatch("{id:int}/reschedule")]
+    [Authorize(Roles = "Patient")]
+    public async Task<IActionResult>
+    Reschedule(int id, [FromBody] RescheduleAppointmentDto dto)
+    {
+        var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+
+        var patient = new User { Id = userId, Role = UserRole.Patient };
+
+        try
+        {
+            var updated = await _appointmentService.RescheduleAsync(
+                patient, id, dto.NewStart, dto.NewEnd);
+
+            return Ok(updated);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { error = ex.Message });
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Forbid();
+        }
     }
 }

--- a/backend/HealthcareBooking.Api/Controller/AvailabilityController.cs
+++ b/backend/HealthcareBooking.Api/Controller/AvailabilityController.cs
@@ -37,7 +37,7 @@ public class AvailabilityController : ControllerBase
         }
         catch (InvalidOperationException ex)
         {
-            return BadRequest(ex.Message);
+            return Conflict(ex.Message);
         }
     }
 

--- a/backend/HealthcareBooking.Api/Dto/AppointmentResponse.cs
+++ b/backend/HealthcareBooking.Api/Dto/AppointmentResponse.cs
@@ -1,0 +1,12 @@
+using HealthcareBooking.Api.Entities;
+
+namespace HealthcareBooking.Api.Dto;
+
+public record AppointmentResponse(
+    int Id,
+    int CaregiverId,
+    int PatientId,
+    DateTime Start,
+    DateTime End,
+    AppointmentStatus Status
+);

--- a/backend/HealthcareBooking.Api/Dto/CreateAppointmentDto.cs
+++ b/backend/HealthcareBooking.Api/Dto/CreateAppointmentDto.cs
@@ -1,0 +1,8 @@
+namespace HealthcareBooking.Api.Dto;
+
+public class CreateAppointmentDto
+{
+    public int CaregiverId { get; set; }
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
+}

--- a/backend/HealthcareBooking.Api/Dto/RescheduleAppointmentDto.cs
+++ b/backend/HealthcareBooking.Api/Dto/RescheduleAppointmentDto.cs
@@ -1,0 +1,7 @@
+namespace HealthcareBooking.Api.Dto;
+
+public class RescheduleAppointmentDto
+{
+  public DateTime NewStart { get; set; }
+  public DateTime NewEnd { get; set; }
+}

--- a/backend/HealthcareBooking.Api/Program.cs
+++ b/backend/HealthcareBooking.Api/Program.cs
@@ -30,6 +30,7 @@ builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<JwtTokenService>();
 builder.Services.AddScoped<AvailabilityService>();
 builder.Services.AddScoped<AvailableAppointmentService>();
+builder.Services.AddScoped<AppointmentService>();
 
 // Authentication / Authorization
 builder.Services

--- a/backend/HealthcareBooking.Api/Service/AppointmentService.cs
+++ b/backend/HealthcareBooking.Api/Service/AppointmentService.cs
@@ -1,0 +1,107 @@
+namespace HealthcareBooking.Api.Service;
+
+using HealthcareBooking.Api.Data;
+using HealthcareBooking.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+public class AppointmentService
+{
+    private readonly AppDbContext _context;
+
+    public AppointmentService(AppDbContext context) { _context = context; }
+
+    public async Task<Appointment> BookAsync(User patient, int caregiverId,
+                                             DateTime start, DateTime end)
+    {
+        if (patient.Role != UserRole.Patient)
+            throw new InvalidOperationException(
+                "Only patients can book appointments.");
+
+        if (start >= end)
+            throw new InvalidOperationException("Invalid appointment time range.");
+
+        start = DateTime.SpecifyKind(start, DateTimeKind.Utc);
+        end = DateTime.SpecifyKind(end, DateTimeKind.Utc);
+
+        var availabilityExists = await _context.Availabilities.AnyAsync(
+            a => a.CaregiverId == caregiverId && a.Start <= start && a.End >= end);
+
+        if (!availabilityExists)
+            throw new InvalidOperationException(
+                "Selected time is not within caregiver availability.");
+
+        var overlaps = await _context.Appointments.AnyAsync(
+            a => a.CaregiverId == caregiverId &&
+                 a.Status == AppointmentStatus.Booked && a.Start < end &&
+                 a.End > start);
+
+        if (overlaps)
+            throw new InvalidOperationException("Time slot is already booked.");
+
+        var appointment =
+            new Appointment
+            {
+                PatientId = patient.Id,
+                CaregiverId = caregiverId,
+                Start = start,
+                End = end
+            };
+
+        _context.Appointments.Add(appointment);
+        await _context.SaveChangesAsync();
+
+        return appointment;
+    }
+
+    public async Task CancelAsync(User patient, int appointmentId)
+    {
+        var appointment = await _context.Appointments.FirstOrDefaultAsync(
+            a => a.Id == appointmentId);
+
+        if (appointment == null)
+            throw new KeyNotFoundException("Appointment not found.");
+
+        if (appointment.PatientId != patient.Id)
+            throw new UnauthorizedAccessException(
+                "You cannot cancel someone else's appointment.");
+
+        if (appointment.Status == AppointmentStatus.Cancelled)
+            return; // idempotent
+
+        appointment.Status = AppointmentStatus.Cancelled;
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<Appointment> RescheduleAsync(User patient,
+                                                   int appointmentId,
+                                                   DateTime newStart,
+                                                   DateTime newEnd)
+    {
+        var appointment = await _context.Appointments.FirstOrDefaultAsync(
+            a => a.Id == appointmentId && a.Status == AppointmentStatus.Booked);
+
+        if (appointment == null)
+            throw new KeyNotFoundException("Appointment not found.");
+
+        if (appointment.PatientId != patient.Id)
+            throw new UnauthorizedAccessException();
+
+        newStart = DateTime.SpecifyKind(newStart, DateTimeKind.Utc);
+        newEnd = DateTime.SpecifyKind(newEnd, DateTimeKind.Utc);
+
+        // Double booking check (exclude current appointment)
+        var overlap = await _context.Appointments.AnyAsync(
+            a => a.CaregiverId == appointment.CaregiverId &&
+                 a.Id != appointment.Id && a.Status == AppointmentStatus.Booked &&
+                 a.Start < newEnd && a.End > newStart);
+
+        if (overlap)
+            throw new InvalidOperationException("New time slot is already booked.");
+
+        appointment.Start = newStart;
+        appointment.End = newEnd;
+
+        await _context.SaveChangesAsync();
+        return appointment;
+    }
+}

--- a/backend/HealthcareBooking.Tests/AppointmentServiceTests.cs
+++ b/backend/HealthcareBooking.Tests/AppointmentServiceTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Threading.Tasks;
+using HealthcareBooking.Api.Data;
+using HealthcareBooking.Api.Entities;
+using HealthcareBooking.Api.Service;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace HealthcareBooking.Api.Tests.Services;
+
+public class AppointmentServiceTests
+{
+    // ---------- Helper: In-memory DbContext ----------
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    // ---------- Book appointment: success ----------
+    [Fact]
+    public async Task BookAsync_Should_Create_Appointment_When_Slot_Is_Free()
+    {
+        using var context = CreateDbContext();
+        var service = new AppointmentService(context);
+
+        var caregiver = new User { Id = 1, Role = UserRole.Caregiver };
+        var patient = new User { Id = 2, Role = UserRole.Patient };
+
+        context.Availabilities.Add(new Availability
+        {
+            CaregiverId = caregiver.Id,
+            Start = new DateTime(2026, 1, 26, 9, 0, 0, DateTimeKind.Utc),
+            End = new DateTime(2026, 1, 26, 11, 0, 0, DateTimeKind.Utc)
+        });
+
+        await context.SaveChangesAsync();
+
+        var appointment = await service.BookAsync(
+            patient,
+            caregiver.Id,
+            new DateTime(2026, 1, 26, 9, 30, 0, DateTimeKind.Utc),
+            new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc));
+
+        Assert.NotNull(appointment);
+        Assert.Equal(patient.Id, appointment.PatientId);
+        Assert.Equal(caregiver.Id, appointment.CaregiverId);
+        Assert.Equal(AppointmentStatus.Booked, appointment.Status);
+    }
+
+    // ---------- Book appointment: double booking ----------
+    [Fact]
+    public async Task BookAsync_Should_Throw_When_Double_Booking()
+    {
+        using var context = CreateDbContext();
+        var service = new AppointmentService(context);
+
+        context.Availabilities.Add(new Availability
+        {
+            CaregiverId = 1,
+            Start = new DateTime(2026, 1, 26, 9, 0, 0, DateTimeKind.Utc),
+            End = new DateTime(2026, 1, 26, 11, 0, 0, DateTimeKind.Utc)
+        });
+
+        context.Appointments.Add(new Appointment
+        {
+            CaregiverId = 1,
+            PatientId = 2,
+            Start = new DateTime(2026, 1, 26, 9, 30, 0, DateTimeKind.Utc),
+            End = new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc),
+            Status = AppointmentStatus.Booked
+        });
+
+        await context.SaveChangesAsync();
+
+        var patient = new User { Id = 3, Role = UserRole.Patient };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.BookAsync(
+                patient,
+                1,
+                new DateTime(2026, 1, 26, 9, 45, 0, DateTimeKind.Utc),
+                new DateTime(2026, 1, 26, 10, 15, 0, DateTimeKind.Utc)));
+    }
+
+    // ---------- Reschedule: success ----------
+    [Fact]
+    public async Task RescheduleAsync_Should_Update_Time_When_Slot_Is_Free()
+    {
+        using var context = CreateDbContext();
+        var service = new AppointmentService(context);
+
+        context.Availabilities.Add(new Availability
+        {
+            CaregiverId = 1,
+            Start = new DateTime(2026, 1, 26, 9, 0, 0, DateTimeKind.Utc),
+            End = new DateTime(2026, 1, 26, 11, 0, 0, DateTimeKind.Utc)
+        });
+
+        var appointment = new Appointment
+        {
+            Id = 1,
+            CaregiverId = 1,
+            PatientId = 2,
+            Start = new DateTime(2026, 1, 26, 9, 30, 0, DateTimeKind.Utc),
+            End = new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc),
+            Status = AppointmentStatus.Booked
+        };
+
+        context.Appointments.Add(appointment);
+        await context.SaveChangesAsync();
+
+        var patient = new User { Id = 2, Role = UserRole.Patient };
+
+        var updated = await service.RescheduleAsync(
+            patient,
+            appointment.Id,
+            new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 1, 26, 10, 30, 0, DateTimeKind.Utc));
+
+        Assert.Equal(
+            new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc),
+            updated.Start);
+
+        Assert.Equal(
+            new DateTime(2026, 1, 26, 10, 30, 0, DateTimeKind.Utc),
+            updated.End);
+    }
+
+    // ---------- Reschedule: overlap ----------
+    [Fact]
+    public async Task RescheduleAsync_Should_Throw_When_New_Time_Overlaps()
+    {
+        using var context = CreateDbContext();
+        var service = new AppointmentService(context);
+
+        context.Availabilities.Add(new Availability
+        {
+            CaregiverId = 1,
+            Start = new DateTime(2026, 1, 26, 9, 0, 0, DateTimeKind.Utc),
+            End = new DateTime(2026, 1, 26, 11, 0, 0, DateTimeKind.Utc)
+        });
+
+        context.Appointments.AddRange(
+            new Appointment
+            {
+                Id = 1,
+                CaregiverId = 1,
+                PatientId = 2,
+                Start = new DateTime(2026, 1, 26, 9, 30, 0, DateTimeKind.Utc),
+                End = new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc),
+                Status = AppointmentStatus.Booked
+            },
+            new Appointment
+            {
+                Id = 2,
+                CaregiverId = 1,
+                PatientId = 3,
+                Start = new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc),
+                End = new DateTime(2026, 1, 26, 10, 30, 0, DateTimeKind.Utc),
+                Status = AppointmentStatus.Booked
+            }
+        );
+
+        await context.SaveChangesAsync();
+
+        var patient = new User { Id = 2, Role = UserRole.Patient };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.RescheduleAsync(
+                patient,
+                1,
+                new DateTime(2026, 1, 26, 10, 0, 0, DateTimeKind.Utc),
+                new DateTime(2026, 1, 26, 10, 30, 0, DateTimeKind.Utc)));
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces patient appointment booking and rescheduling functionality,
fully integrated with caregiver availability and double-booking prevention.

## Key changes
- Added POST /appointments endpoint for booking appointments
- Added PATCH /appointments/{id}/reschedule endpoint for rescheduling
- Enforced role-based access control for appointment operations
- Validated bookings against caregiver availability windows
- Prevented overlapping appointments at the service layer
- Introduced response DTOs to decouple API responses from EF entities
- Added unit tests for AppointmentService using EF Core InMemory

## Testing
- Added automated unit tests covering booking and rescheduling scenarios
- Tests include success cases and conflict prevention
- All tests pass via `dotnet test`

## Notes
This closes issue #18 for booking api