### PR TITLE
feat(patient-booking-ui) added ui for patients who want to book

### DIFF
--- a/backend/HealthcareBooking.Api/Controller/AppointmentsController.cs
+++ b/backend/HealthcareBooking.Api/Controller/AppointmentsController.cs
@@ -7,6 +7,7 @@ using System.Security.Claims;
 
 namespace HealthcareBooking.Api.Controllers;
 
+
 [ApiController]
 [Route("v1/api/appointments")]
 [Authorize]
@@ -23,44 +24,57 @@ public class AppointmentsController : ControllerBase
         _appointmentService = appointmentService;
     }
 
-    // GET /v1/api/appointments/available?caregiverId=5
-    // Allows patients to fetch available appointment slots
+    // GET /v1/api/appointments/available
+    // GET /v1/api/appointments/available?caregiverId=9
+    // Returns available appointment slots.
+    // If caregiverId is provided, filters by caregiver.
+    // Otherwise returns slots across all caregivers.
     [HttpGet("available")]
-    public async Task<IActionResult> GetAvailable([FromQuery] int caregiverId)
+    [Authorize(Roles = "Patient")]
+    public async Task<IActionResult> GetAvailable([FromQuery] int? caregiverId)
     {
-        if (caregiverId <= 0)
-            return BadRequest("caregiverId is required");
+        if (caregiverId.HasValue)
+        {
+            var slots = await _availableAppointmentService
+                .GetAvailableSlotsAsync(caregiverId.Value);
 
-        var slots =
-            await _availableAppointmentService.GetAvailableSlotsAsync(caregiverId);
+            return Ok(slots);
+        }
 
-        return Ok(slots);
+        var allSlots = await _availableAppointmentService
+            .GetAllAvailableSlotsAsync();
+
+        return Ok(allSlots);
     }
 
     // POST /v1/api/appointments
-    // Allows a patient to book an appointment
     [HttpPost]
     [Authorize(Roles = "Patient")]
     public async Task<IActionResult> Book([FromBody] CreateAppointmentDto dto)
     {
-        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        var roleClaim = User.FindFirst(ClaimTypes.Role)?.Value;
+        var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
 
-        if (!int.TryParse(userIdClaim, out var userId))
-            return Unauthorized();
-
-        var patient =
-            new User { Id = userId, Role = Enum.Parse<UserRole>(roleClaim!) };
+        var patient = new User
+        {
+            Id = userId,
+            Role = UserRole.Patient
+        };
 
         try
         {
             var appointment = await _appointmentService.BookAsync(
-                patient, dto.CaregiverId, dto.Start, dto.End);
+                patient,
+                dto.CaregiverId,
+                dto.Start,
+                dto.End);
 
             return Created(string.Empty, new AppointmentResponse(
-                                             appointment.Id, appointment.CaregiverId,
-                                             appointment.PatientId, appointment.Start,
-                                             appointment.End, appointment.Status));
+                appointment.Id,
+                appointment.CaregiverId,
+                appointment.PatientId,
+                appointment.Start,
+                appointment.End,
+                appointment.Status));
         }
         catch (InvalidOperationException ex)
         {
@@ -69,20 +83,27 @@ public class AppointmentsController : ControllerBase
     }
 
     // PATCH /v1/api/appointments/{id}/reschedule
-    // Allows patients to reschedule their appointments
     [HttpPatch("{id:int}/reschedule")]
     [Authorize(Roles = "Patient")]
-    public async Task<IActionResult>
-    Reschedule(int id, [FromBody] RescheduleAppointmentDto dto)
+    public async Task<IActionResult> Reschedule(
+        int id,
+        [FromBody] RescheduleAppointmentDto dto)
     {
         var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
 
-        var patient = new User { Id = userId, Role = UserRole.Patient };
+        var patient = new User
+        {
+            Id = userId,
+            Role = UserRole.Patient
+        };
 
         try
         {
             var updated = await _appointmentService.RescheduleAsync(
-                patient, id, dto.NewStart, dto.NewEnd);
+                patient,
+                id,
+                dto.NewStart,
+                dto.NewEnd);
 
             return Ok(updated);
         }

--- a/backend/HealthcareBooking.Api/Service/AvailableAppointmentService.cs
+++ b/backend/HealthcareBooking.Api/Service/AvailableAppointmentService.cs
@@ -14,14 +14,13 @@ public class AvailableAppointmentService
         _context = context;
     }
 
-    // Returns future appointment slots for a caregiver,
+    // Returns future appointment slots for a single caregiver,
     // enriched with caregiver display information.
     public async Task<IReadOnlyList<AvailableAppointmentResponse>>
         GetAvailableSlotsAsync(int caregiverId)
     {
         var now = DateTime.UtcNow;
 
-        // Load caregiver display info ONCE
         var caregiver = await _context.Users
             .Where(u => u.Id == caregiverId && u.Role == UserRole.Caregiver)
             .Select(u => new CaregiverSummaryDto(
@@ -33,15 +32,11 @@ public class AvailableAppointmentService
         if (caregiver == null)
             return Array.Empty<AvailableAppointmentResponse>();
 
-        // Load future availability windows
         var availabilities = await _context.Availabilities
-            .Where(a =>
-                a.CaregiverId == caregiverId &&
-                a.End > now)
+            .Where(a => a.CaregiverId == caregiverId && a.End > now)
             .OrderBy(a => a.Start)
             .ToListAsync();
 
-        // Load future booked appointments
         var appointments = await _context.Appointments
             .Where(a =>
                 a.CaregiverId == caregiverId &&
@@ -50,7 +45,77 @@ public class AvailableAppointmentService
             .OrderBy(a => a.Start)
             .ToListAsync();
 
-        var availableSlots = new List<AvailableAppointmentResponse>();
+        return BuildSlots(caregiver, availabilities, appointments, now);
+    }
+
+    // Returns future appointment slots across ALL caregivers
+    public async Task<IReadOnlyList<AvailableAppointmentResponse>>
+        GetAllAvailableSlotsAsync()
+    {
+        var now = DateTime.UtcNow;
+
+        // Load all caregivers with display info
+        var caregivers = await _context.Users
+            .Where(u => u.Role == UserRole.Caregiver)
+            .Select(u => new CaregiverSummaryDto(
+                u.Id,
+                u.FirstName,
+                u.LastName))
+            .ToListAsync();
+
+        if (caregivers.Count == 0)
+            return Array.Empty<AvailableAppointmentResponse>();
+
+        var caregiverIds = caregivers.Select(c => c.Id).ToList();
+
+        // Load all future availabilities
+        var availabilities = await _context.Availabilities
+            .Where(a =>
+                caregiverIds.Contains(a.CaregiverId) &&
+                a.End > now)
+            .OrderBy(a => a.Start)
+            .ToListAsync();
+
+        // Load all future booked appointments
+        var appointments = await _context.Appointments
+            .Where(a =>
+                caregiverIds.Contains(a.CaregiverId) &&
+                a.Status == AppointmentStatus.Booked &&
+                a.End > now)
+            .OrderBy(a => a.Start)
+            .ToListAsync();
+
+        var results = new List<AvailableAppointmentResponse>();
+
+        foreach (var caregiver in caregivers)
+        {
+            var caregiverAvailabilities = availabilities
+                .Where(a => a.CaregiverId == caregiver.Id)
+                .ToList();
+
+            var caregiverAppointments = appointments
+                .Where(a => a.CaregiverId == caregiver.Id)
+                .ToList();
+
+            results.AddRange(
+                BuildSlots(
+                    caregiver,
+                    caregiverAvailabilities,
+                    caregiverAppointments,
+                    now));
+        }
+
+        return results;
+    }
+
+    // Shared slot-splitting logic (single source of truth)
+    private static List<AvailableAppointmentResponse> BuildSlots(
+        CaregiverSummaryDto caregiver,
+        List<Availability> availabilities,
+        List<Appointment> appointments,
+        DateTime now)
+    {
+        var slots = new List<AvailableAppointmentResponse>();
 
         foreach (var availability in availabilities)
         {
@@ -68,28 +133,19 @@ public class AvailableAppointmentService
 
             foreach (var appointment in overlappingAppointments)
             {
-                TryAddSlot(
-                    availableSlots,
-                    caregiver,
-                    slotStart,
-                    appointment.Start);
+                TryAddSlot(slots, caregiver, slotStart, appointment.Start);
 
                 slotStart = appointment.End < now
                     ? now
                     : appointment.End;
             }
 
-            TryAddSlot(
-                availableSlots,
-                caregiver,
-                slotStart,
-                slotEnd);
+            TryAddSlot(slots, caregiver, slotStart, slotEnd);
         }
 
-        return availableSlots;
+        return slots;
     }
 
-    // Adds a slot only if it represents a real, usable time range.
     private static void TryAddSlot(
         List<AvailableAppointmentResponse> slots,
         CaregiverSummaryDto caregiver,

--- a/frontend/src/api/appointments.ts
+++ b/frontend/src/api/appointments.ts
@@ -1,7 +1,13 @@
 import { http } from "./http";
 
+export interface CaregiverIdentity {
+  id: number;
+  firstName: string;
+  lastName: string;
+}
+
 export interface AvailableAppointmentSlot {
-  caregiverId: number;
+  caregiver: CaregiverIdentity;
   start: string; // ISO UTC string from backend
   end: string; // ISO UTC string from backend
 }
@@ -21,15 +27,31 @@ export interface Appointment {
   status: number;
 }
 
-export async function listAvailableAppointmentSlots(caregiverId: number) {
+export async function listAvailableAppointmentSlots(caregiverId?: number) {
+  // FYI: backend supports both:
+  // - all caregivers: GET /appointments/available
+  // - specific caregiver: GET /appointments/available?caregiverId=123
+  // So we keep caregiverId optional and only send it when we actually have one.
   const res = await http.get<AvailableAppointmentSlot[]>("/appointments/available", {
-    params: { caregiverId },
+    params: caregiverId ? { caregiverId } : undefined,
   });
   return res.data;
 }
 
 export async function bookAppointment(dto: BookAppointmentRequest) {
+  // This is the real booking call. Backend owns validation (conflicts, time windows, etc).
   const res = await http.post<Appointment>("/appointments", dto);
+  return res.data;
+}
+
+export interface RescheduleAppointmentRequest {
+  newStart: string;
+  newEnd: string;
+}
+
+export async function rescheduleAppointment(appointmentId: number, dto: RescheduleAppointmentRequest) {
+  // Optional feature: reschedule existing appointment to a new window.
+  const res = await http.patch<Appointment>(`/appointments/${appointmentId}/reschedule`, dto);
   return res.data;
 }
 

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -8,6 +8,8 @@ export interface LoginDto {
 export interface RegisterDto {
   email: string;
   password: string;
+  firstName: string;
+  lastName: string;
 }
 
 export async function login(dto: LoginDto) {

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -5,6 +5,8 @@ interface User {
   id: number;
   email: string;
   role: string | number;
+  firstName?: string;
+  lastName?: string;
 }
 
 export function normalizeRoleId(role: string | number | undefined): 0 | 1 | null {

--- a/frontend/src/components/appointments/PatientAppointmentBooking.tsx
+++ b/frontend/src/components/appointments/PatientAppointmentBooking.tsx
@@ -4,40 +4,26 @@ import {
   listAvailableAppointmentSlots,
   type AvailableAppointmentSlot,
 } from "../../api/appointments";
+import ConfirmDialog from "../ui/ConfirmDialog";
 import "./patientAppointmentBooking.css";
 
 type Toast = { kind: "success" | "error"; message: string };
 
-type SavedCaregiver = { id: number; label?: string };
-
-const SAVED_CAREGIVERS_KEY = "savedCaregivers";
-
-function loadSavedCaregivers(): SavedCaregiver[] {
-  try {
-    const raw = localStorage.getItem(SAVED_CAREGIVERS_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed
-      .map((x: any) => ({
-        id: Number(x?.id),
-        label: typeof x?.label === "string" ? x.label : undefined,
-      }))
-      .filter(x => Number.isFinite(x.id) && x.id > 0);
-  } catch {
-    return [];
-  }
-}
-
-function saveSavedCaregivers(list: SavedCaregiver[]) {
-  localStorage.setItem(SAVED_CAREGIVERS_KEY, JSON.stringify(list));
-}
-
 function slotKey(s: AvailableAppointmentSlot) {
-  return `${s.caregiverId}:${s.start}:${s.end}`;
+  // Unique key for a slot. Backend basically treats (caregiver + start + end) as the identity here.
+  return `${s.caregiver.id}:${s.start}:${s.end}`;
+}
+
+function displayCaregiverName(caregiver: AvailableAppointmentSlot["caregiver"]) {
+  // Backend might return empty first/last name sometimes. If that happens, we still show something sane.
+  const first = (caregiver.firstName ?? "").trim();
+  const last = (caregiver.lastName ?? "").trim();
+  const full = `${first} ${last}`.trim();
+  return full || `Caregiver #${caregiver.id}`;
 }
 
 function extractErrorMessage(err: any, fallback: string) {
+  // We always want a user-visible error. No "silent fail" / console-only errors.
   const status = err?.response?.status;
   if (status === 401 || status === 403) return "You are not authorized. Please log in again.";
 
@@ -52,7 +38,7 @@ function extractErrorMessage(err: any, fallback: string) {
 function toLocalDateKey(isoUtc: string) {
   const d = new Date(isoUtc);
   if (Number.isNaN(d.getTime())) return "Invalid date";
-  // YYYY-MM-DD in local time
+  // YYYY-MM-DD in local time. We use this for grouping and filtering by day.
   const yyyy = d.getFullYear();
   const mm = String(d.getMonth() + 1).padStart(2, "0");
   const dd = String(d.getDate()).padStart(2, "0");
@@ -79,40 +65,75 @@ function calcDurationMinutes(startIso: string, endIso: string) {
   return mins > 0 ? mins : null;
 }
 
-export default function PatientAppointmentBooking() {
-  const [savedCaregivers, setSavedCaregivers] = useState<SavedCaregiver[]>(() => loadSavedCaregivers());
-  const [selectedCaregiverId, setSelectedCaregiverId] = useState<number | null>(
-    savedCaregivers.length ? savedCaregivers[0]!.id : null
-  );
-  const [caregiverIdInput, setCaregiverIdInput] = useState("");
-  const [caregiverLabelInput, setCaregiverLabelInput] = useState("");
+type CaregiverOption = { id: number; firstName: string; lastName: string };
 
-  const caregiverId = useMemo(() => {
-    if (selectedCaregiverId) return selectedCaregiverId;
-    const n = Number(caregiverIdInput);
-    return Number.isFinite(n) && n > 0 ? n : null;
-  }, [selectedCaregiverId, caregiverIdInput]);
+function caregiverLabel(c: CaregiverOption) {
+  const full = `${(c.firstName ?? "").trim()} ${(c.lastName ?? "").trim()}`.trim();
+  return full || `Caregiver #${c.id}`;
+}
 
+export default function PatientAppointmentBooking({
+  onBooked,
+  onRequestClose,
+}: {
+  onBooked?: () => void;
+  onRequestClose?: () => void;
+}) {
+  // null => All caregivers (we show everything by default)
+  const [selectedCaregiverId, setSelectedCaregiverId] = useState<number | null>(null);
+
+  // dateFilter === "all" means "show all days"
   const [dateFilter, setDateFilter] = useState<"all" | string>("all"); // local YYYY-MM-DD
-  const [slots, setSlots] = useState<AvailableAppointmentSlot[]>([]);
+  const [allSlots, setAllSlots] = useState<AvailableAppointmentSlot[]>([]);
   const [slotsLoading, setSlotsLoading] = useState(false);
   const [slotsError, setSlotsError] = useState<string>("");
 
+  // bookingKey is our "lock" so we don't spam the API / double-book.
   const [bookingKey, setBookingKey] = useState<string | null>(null);
   const [toast, setToast] = useState<Toast | null>(null);
 
+  const [pageSize, setPageSize] = useState<10 | 20 | 50>(20);
+  const [page, setPage] = useState(1);
+  // When you click "Book", we store the slot here and show the real confirm dialog.
+  const [confirmSlot, setConfirmSlot] = useState<AvailableAppointmentSlot | null>(null);
+
   const toastTimer = useRef<number | null>(null);
   function showToast(next: Toast) {
+    // Quick feedback for success/errors. Auto-hides after a few seconds.
     setToast(next);
     if (toastTimer.current) window.clearTimeout(toastTimer.current);
     toastTimer.current = window.setTimeout(() => setToast(null), 4500);
   }
 
+  const visibleSlots = useMemo(() => {
+    // Filter by caregiver. If "All caregivers" then don't filter.
+    return selectedCaregiverId
+      ? allSlots.filter(s => s.caregiver.id === selectedCaregiverId)
+      : allSlots;
+  }, [allSlots, selectedCaregiverId]);
+
+  const filteredSortedSlots = useMemo(() => {
+    // Filter by date, then sort by start time so it reads like a real schedule.
+    const base =
+      dateFilter === "all"
+        ? visibleSlots
+        : visibleSlots.filter(s => toLocalDateKey(s.start) === dateFilter);
+    return [...base].sort((a, b) => a.start.localeCompare(b.start));
+  }, [visibleSlots, dateFilter]);
+
+  const totalSlots = filteredSortedSlots.length;
+  const totalPages = Math.max(1, Math.ceil(totalSlots / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageSlots = useMemo(() => {
+    const start = (safePage - 1) * pageSize;
+    return filteredSortedSlots.slice(start, start + pageSize);
+  }, [filteredSortedSlots, pageSize, safePage]);
+
   const grouped = useMemo(() => {
+    // Group the current page by local day so the list is easy to scan.
     const map = new Map<string, AvailableAppointmentSlot[]>();
-    for (const s of slots) {
+    for (const s of pageSlots) {
       const key = toLocalDateKey(s.start);
-      if (dateFilter !== "all" && key !== dateFilter) continue;
       const arr = map.get(key) ?? [];
       arr.push(s);
       map.set(key, arr);
@@ -123,52 +144,70 @@ export default function PatientAppointmentBooking() {
       arr.sort((x, y) => x.start.localeCompare(y.start));
     }
     return days;
-  }, [slots, dateFilter]);
+  }, [pageSlots]);
 
   const availableDateKeys = useMemo(() => {
+    // This powers the "Date" dropdown. It should reflect current caregiver filter.
     const set = new Set<string>();
-    for (const s of slots) set.add(toLocalDateKey(s.start));
+    for (const s of visibleSlots) set.add(toLocalDateKey(s.start));
     return Array.from(set).sort((a, b) => a.localeCompare(b));
-  }, [slots]);
+  }, [visibleSlots]);
 
   const loadAbortRef = useRef<AbortController | null>(null);
 
-  async function loadSlots(nextCaregiverId: number) {
+  const [caregiverOptions, setCaregiverOptions] = useState<CaregiverOption[]>([]);
+  const [caregiverOptionsLoading, setCaregiverOptionsLoading] = useState(false);
+  const [caregiverOptionsError, setCaregiverOptionsError] = useState("");
+
+  async function loadAvailability() {
+    // One call to load "truth from backend":
+    // - all caregivers + all slots
+    // - then we derive caregiver dropdown from that list
+    setCaregiverOptionsError("");
+    setCaregiverOptionsLoading(true);
     setSlotsError("");
     setSlotsLoading(true);
-    loadAbortRef.current?.abort();
-    const controller = new AbortController();
-    loadAbortRef.current = controller;
     try {
-      const data = await listAvailableAppointmentSlots(nextCaregiverId);
-      if (controller.signal.aborted) return;
-      setSlots(data);
-      // If a date is selected, keep it only if it's still present.
+      // Backend supports listing slots across caregivers; we derive caregiver list from that response.
+      const all = await listAvailableAppointmentSlots();
+      setAllSlots(all);
+      setPage(1);
+      const unique = new Map<number, CaregiverOption>();
+      for (const s of all) {
+        unique.set(s.caregiver.id, {
+          id: s.caregiver.id,
+          firstName: s.caregiver.firstName,
+          lastName: s.caregiver.lastName,
+        });
+      }
+      const list = Array.from(unique.values()).sort((a, b) =>
+        caregiverLabel(a).localeCompare(caregiverLabel(b))
+      );
+      setCaregiverOptions(list);
+
+      // Keep date filter only if it still exists
       setDateFilter(prev => {
         if (prev === "all") return prev;
-        const exists = data.some(s => toLocalDateKey(s.start) === prev);
+        const exists = all.some(s => toLocalDateKey(s.start) === prev);
         return exists ? prev : "all";
       });
     } catch (err: any) {
-      if (controller.signal.aborted) return;
-      setSlots([]);
-      setSlotsError(extractErrorMessage(err, "Failed to load available slots."));
+      setAllSlots([]);
+      setCaregiverOptions([]);
+      const msg = extractErrorMessage(err, "Failed to load availability.");
+      setCaregiverOptionsError(msg);
+      setSlotsError(msg);
     } finally {
-      if (!controller.signal.aborted) setSlotsLoading(false);
+      setCaregiverOptionsLoading(false);
+      setSlotsLoading(false);
     }
   }
 
-  // Auto-load when caregiver changes (debounced lightly)
+  // initial load (caregivers list)
   useEffect(() => {
-    if (!caregiverId) {
-      setSlots([]);
-      setSlotsError("");
-      return;
-    }
-    const t = window.setTimeout(() => loadSlots(caregiverId), 250);
-    return () => window.clearTimeout(t);
+    loadAvailability();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [caregiverId]);
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -177,72 +216,49 @@ export default function PatientAppointmentBooking() {
     };
   }, []);
 
-  function onSelectSaved(value: string) {
-    if (value === "custom") {
-      setSelectedCaregiverId(null);
-      return;
-    }
-    const id = Number(value);
-    if (Number.isFinite(id) && id > 0) {
-      setSelectedCaregiverId(id);
-      setCaregiverIdInput("");
-    }
-  }
+  useEffect(() => {
+    // Reset pagination when filters change, otherwise you can land on a page that doesn't exist anymore.
+    setPage(1);
+  }, [selectedCaregiverId, dateFilter]);
 
-  function addSavedCaregiver() {
-    const id = caregiverId ?? Number(caregiverIdInput);
-    if (!Number.isFinite(id) || id <= 0) {
-      showToast({ kind: "error", message: "Enter a valid caregiver ID to save." });
-      return;
-    }
-    const next: SavedCaregiver = { id, label: caregiverLabelInput.trim() || undefined };
-    const merged = [next, ...savedCaregivers.filter(c => c.id !== id)].slice(0, 10);
-    setSavedCaregivers(merged);
-    saveSavedCaregivers(merged);
-    setSelectedCaregiverId(id);
-    setCaregiverIdInput("");
-    setCaregiverLabelInput("");
-    showToast({ kind: "success", message: "Saved caregiver." });
-  }
-
-  function removeSavedCaregiver(id: number) {
-    const merged = savedCaregivers.filter(c => c.id !== id);
-    setSavedCaregivers(merged);
-    saveSavedCaregivers(merged);
-    if (selectedCaregiverId === id) setSelectedCaregiverId(merged.length ? merged[0]!.id : null);
-    showToast({ kind: "success", message: "Removed saved caregiver." });
-  }
-
-  async function handleBook(slot: AvailableAppointmentSlot) {
+  async function performBooking(slot: AvailableAppointmentSlot) {
+    // Actual booking call (triggered ONLY after user confirms in the real dialog)
     const key = slotKey(slot);
     if (bookingKey) return;
 
-    const ok = window.confirm(
-      `Book appointment with caregiver #${slot.caregiverId} on ${formatLocalDateHeading(
-        toLocalDateKey(slot.start)
-      )} from ${formatLocalTime(slot.start)} to ${formatLocalTime(slot.end)}?`
-    );
-    if (!ok) return;
-
     setBookingKey(key);
     try {
-      await bookAppointment({ caregiverId: slot.caregiverId, start: slot.start, end: slot.end });
+      await bookAppointment({ caregiverId: slot.caregiver.id, start: slot.start, end: slot.end });
       showToast({ kind: "success", message: "Appointment booked successfully." });
 
-      // Remove immediately, then re-sync.
-      setSlots(prev => prev.filter(s => slotKey(s) !== key));
-      if (caregiverId) await loadSlots(caregiverId);
+      // Remove immediately so the UI feels responsive, then re-sync from backend for correctness.
+      setAllSlots(prev => prev.filter(s => slotKey(s) !== key));
+      await loadAvailability();
+
+      return true;
     } catch (err: any) {
       const status = err?.response?.status;
       const msg = extractErrorMessage(err, "Booking failed. Please try again.");
       showToast({ kind: "error", message: msg });
 
-      // Conflicts: re-sync to reflect latest availability.
-      if (status === 409 && caregiverId) {
-        await loadSlots(caregiverId);
+      // Conflicts: re-sync to reflect latest availability (someone else booked it first).
+      if (status === 409) {
+        await loadAvailability();
       }
+      return false;
     } finally {
       setBookingKey(null);
+    }
+  }
+
+  async function confirmBooking() {
+    // User pressed "Confirm booking" in the dialog.
+    if (!confirmSlot) return;
+    const ok = await performBooking(confirmSlot);
+    if (ok) {
+      setConfirmSlot(null);
+      onBooked?.();
+      onRequestClose?.();
     }
   }
 
@@ -262,88 +278,84 @@ export default function PatientAppointmentBooking() {
         </div>
       )}
 
+      <ConfirmDialog
+        open={!!confirmSlot}
+        title="Confirm booking"
+        description="Please review the appointment details before confirming."
+        confirmText="Confirm booking"
+        cancelText="Cancel"
+        loading={bookingKey !== null}
+        onCancel={() => (bookingKey ? null : setConfirmSlot(null))}
+        onConfirm={confirmBooking}
+      >
+        {confirmSlot ? (
+          <div className="booking-confirm-details">
+            <div className="booking-confirm-row">
+              <div className="booking-confirm-label">Caregiver</div>
+              <div className="booking-confirm-value">{displayCaregiverName(confirmSlot.caregiver)}</div>
+            </div>
+            <div className="booking-confirm-row">
+              <div className="booking-confirm-label">Date</div>
+              <div className="booking-confirm-value">{formatLocalDateHeading(toLocalDateKey(confirmSlot.start))}</div>
+            </div>
+            <div className="booking-confirm-row">
+              <div className="booking-confirm-label">Time</div>
+              <div className="booking-confirm-value">
+                {formatLocalTime(confirmSlot.start)} – {formatLocalTime(confirmSlot.end)}
+              </div>
+            </div>
+            <div className="booking-confirm-row">
+              <div className="booking-confirm-label">Duration</div>
+              <div className="booking-confirm-value">
+                {calcDurationMinutes(confirmSlot.start, confirmSlot.end) ?? "—"} min
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </ConfirmDialog>
+
       <div className="booking-panel">
         <div className="booking-row">
           <div className="booking-field">
-            <label className="booking-label" htmlFor="savedCaregiver">
+            <label className="booking-label" htmlFor="caregiverSelect">
               Caregiver
             </label>
             <select
-              id="savedCaregiver"
+              id="caregiverSelect"
               className="booking-select"
-              value={selectedCaregiverId ?? "custom"}
-              onChange={e => onSelectSaved(e.target.value)}
-              disabled={slotsLoading || bookingKey !== null}
+              value={selectedCaregiverId ?? "all"}
+              onChange={e => {
+                const v = e.target.value;
+                setSelectedCaregiverId(v === "all" ? null : Number(v) || null);
+                setDateFilter("all");
+              }}
+              disabled={caregiverOptionsLoading || slotsLoading || bookingKey !== null}
             >
-              {savedCaregivers.map(c => (
+              <option value="all">All caregivers</option>
+              {!caregiverOptionsLoading && caregiverOptions.length === 0 && (
+                <option value="">No caregivers available</option>
+              )}
+              {caregiverOptions.map(c => (
                 <option key={c.id} value={c.id}>
-                  {c.label ? `${c.label} (#${c.id})` : `Caregiver #${c.id}`}
+                  {caregiverLabel(c)}
                 </option>
               ))}
-              <option value="custom">Enter a caregiver ID…</option>
             </select>
           </div>
 
-          {selectedCaregiverId !== null && (
-            <div className="booking-inline-actions">
-              <button
-                className="booking-link-button"
-                type="button"
-                onClick={() => removeSavedCaregiver(selectedCaregiverId)}
-                disabled={slotsLoading || bookingKey !== null}
-              >
-                Remove saved
-              </button>
-            </div>
-          )}
+          <div className="booking-inline-actions booking-inline-actions-right">
+            <button
+              className="booking-button secondary"
+              type="button"
+              onClick={loadAvailability}
+              disabled={caregiverOptionsLoading || slotsLoading || bookingKey !== null}
+            >
+              {caregiverOptionsLoading ? "Loading..." : "Refresh availability"}
+            </button>
+          </div>
         </div>
 
-        {selectedCaregiverId === null && (
-          <div className="booking-row">
-            <div className="booking-field">
-              <label className="booking-label" htmlFor="caregiverId">
-                Caregiver ID
-              </label>
-              <input
-                id="caregiverId"
-                className="booking-input"
-                type="number"
-                min={1}
-                inputMode="numeric"
-                placeholder="e.g. 7"
-                value={caregiverIdInput}
-                onChange={e => setCaregiverIdInput(e.target.value)}
-                disabled={slotsLoading || bookingKey !== null}
-              />
-            </div>
-
-            <div className="booking-field">
-              <label className="booking-label" htmlFor="caregiverLabel">
-                Label (optional)
-              </label>
-              <input
-                id="caregiverLabel"
-                className="booking-input"
-                type="text"
-                placeholder="e.g. Dr. Chen"
-                value={caregiverLabelInput}
-                onChange={e => setCaregiverLabelInput(e.target.value)}
-                disabled={slotsLoading || bookingKey !== null}
-              />
-            </div>
-
-            <div className="booking-inline-actions">
-              <button
-                className="booking-button"
-                type="button"
-                onClick={addSavedCaregiver}
-                disabled={!caregiverId || slotsLoading || bookingKey !== null}
-              >
-                Save caregiver
-              </button>
-            </div>
-          </div>
-        )}
+        {caregiverOptionsError && <div className="booking-alert error">{caregiverOptionsError}</div>}
 
         <div className="booking-row booking-row-tight">
           <div className="booking-field">
@@ -355,7 +367,7 @@ export default function PatientAppointmentBooking() {
               className="booking-select"
               value={dateFilter}
               onChange={e => setDateFilter(e.target.value as any)}
-              disabled={slotsLoading || bookingKey !== null || slots.length === 0}
+              disabled={slotsLoading || bookingKey !== null || visibleSlots.length === 0}
             >
               <option value="all">All available days</option>
               {availableDateKeys.map(k => (
@@ -370,8 +382,8 @@ export default function PatientAppointmentBooking() {
             <button
               className="booking-button secondary"
               type="button"
-              onClick={() => caregiverId && loadSlots(caregiverId)}
-              disabled={!caregiverId || slotsLoading || bookingKey !== null}
+              onClick={loadAvailability}
+              disabled={slotsLoading || bookingKey !== null}
             >
               {slotsLoading ? "Refreshing..." : "Refresh"}
             </button>
@@ -382,50 +394,104 @@ export default function PatientAppointmentBooking() {
       {slotsError && <div className="booking-alert error">{slotsError}</div>}
 
       <div className="booking-results">
-        {!caregiverId && <div className="booking-empty">Choose a caregiver to see available slots.</div>}
-        {caregiverId && !slotsLoading && !slotsError && slots.length === 0 && (
-          <div className="booking-empty">No available slots found for this caregiver.</div>
-        )}
-
-        {grouped.map(([dayKey, daySlots]) => (
-          <div key={dayKey} className="booking-day">
-            <div className="booking-day-header">
-              <div className="booking-day-title">{formatLocalDateHeading(dayKey)}</div>
-              <div className="booking-day-count">{daySlots.length} slot(s)</div>
+        {!slotsLoading && !slotsError && allSlots.length > 0 && (
+          <div className="booking-pagination" role="navigation" aria-label="Appointment slots pagination">
+            <div className="booking-pagination-left">
+              <div className="booking-pagination-count">
+                Showing <strong>{totalSlots === 0 ? 0 : (safePage - 1) * pageSize + 1}</strong>–
+                <strong>{Math.min(safePage * pageSize, totalSlots)}</strong> of <strong>{totalSlots}</strong>
+              </div>
             </div>
 
-            <div className="booking-slots">
-              {daySlots.map(s => {
-                const key = slotKey(s);
-                const dur = calcDurationMinutes(s.start, s.end);
-                const isBookingThis = bookingKey === key;
-                return (
-                  <div key={key} className="booking-slot">
-                    <div className="booking-slot-time">
-                      <div className="booking-slot-time-main">
-                        {formatLocalTime(s.start)} – {formatLocalTime(s.end)}
-                      </div>
-                      <div className="booking-slot-time-sub">
-                        Caregiver #{s.caregiverId}
-                        {dur ? ` • ${dur} min` : ""}
-                      </div>
-                    </div>
-                    <div className="booking-slot-actions">
-                      <button
-                        className="slot-book-button"
-                        type="button"
-                        onClick={() => handleBook(s)}
-                        disabled={slotsLoading || bookingKey !== null}
-                      >
-                        {isBookingThis ? "Booking..." : "Book"}
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
+            <div className="booking-pagination-right">
+              <label className="booking-pagination-label" htmlFor="pageSize">
+                Per page
+              </label>
+              <select
+                id="pageSize"
+                className="booking-select booking-pagination-select"
+                value={pageSize}
+                onChange={e => setPageSize(Number(e.target.value) as 10 | 20 | 50)}
+                disabled={slotsLoading || bookingKey !== null}
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+
+              <button
+                className="booking-button secondary booking-pagination-button"
+                type="button"
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={slotsLoading || bookingKey !== null || safePage <= 1}
+              >
+                Previous
+              </button>
+              <div className="booking-pagination-page">
+                Page <strong>{safePage}</strong> / <strong>{totalPages}</strong>
+              </div>
+              <button
+                className="booking-button secondary booking-pagination-button"
+                type="button"
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={slotsLoading || bookingKey !== null || safePage >= totalPages}
+              >
+                Next
+              </button>
             </div>
           </div>
-        ))}
+        )}
+
+        <div className="booking-results-scroll">
+          {!slotsLoading && !slotsError && allSlots.length === 0 && (
+            <div className="booking-empty">No available slots found.</div>
+          )}
+
+          {!slotsLoading && !slotsError && allSlots.length > 0 && totalSlots === 0 && (
+            <div className="booking-empty">No available slots match your filters.</div>
+          )}
+
+          {grouped.map(([dayKey, daySlots]) => (
+            <div key={dayKey} className="booking-day">
+              <div className="booking-day-header">
+                <div className="booking-day-title">{formatLocalDateHeading(dayKey)}</div>
+                <div className="booking-day-count">{daySlots.length} slot(s)</div>
+              </div>
+
+              <div className="booking-slots">
+                {daySlots.map(s => {
+                  const key = slotKey(s);
+                  const dur = calcDurationMinutes(s.start, s.end);
+                  const isBookingThis = bookingKey === key;
+                  const busy = slotsLoading || bookingKey !== null || confirmSlot !== null;
+                  return (
+                    <div key={key} className="booking-slot">
+                      <div className="booking-slot-time">
+                        <div className="booking-slot-time-main">
+                          {formatLocalTime(s.start)} – {formatLocalTime(s.end)}
+                        </div>
+                        <div className="booking-slot-time-sub">
+                          {displayCaregiverName(s.caregiver)}
+                          {dur ? ` • ${dur} min` : ""}
+                        </div>
+                      </div>
+                      <div className="booking-slot-actions">
+                        <button
+                          className="slot-book-button"
+                          type="button"
+                          onClick={() => setConfirmSlot(s)}
+                          disabled={busy}
+                        >
+                          {isBookingThis ? "Booking..." : "Book"}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/components/appointments/patientAppointmentBooking.css
+++ b/frontend/src/components/appointments/patientAppointmentBooking.css
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  height: 100%;
+  min-height: 0;
 }
 
 .booking-header {
@@ -31,7 +33,7 @@
   border-radius: 12px;
   padding: 1rem;
   box-shadow: var(--shadow-sm);
-  border: 1px solid var(--border-color);
+  border: 1px solid black;
 }
 
 .booking-row {
@@ -67,7 +69,7 @@
   height: 42px;
   border-radius: 10px;
   padding: 0 0.9rem;
-  border: 1.5px solid var(--border-color);
+  border: 1.5px solid black;
   background: #ffffff;
   color: #111827;
   outline: none;
@@ -175,6 +177,64 @@
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.booking-results-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  overflow: auto;
+  padding-right: 0.25rem;
+  flex: 1;
+  min-height: 0;
+  scroll-padding-top: 48px;
+  overscroll-behavior: contain;
+  position: relative;
+}
+
+.booking-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  background: linear-gradient(90deg, var(--primary-soft), var(--accent-soft));
+  border: 1px solid rgba(17, 24, 39, 0.12);
+}
+
+.booking-pagination-count {
+  font-weight: 700;
+  color: #111827;
+}
+
+.booking-pagination-right {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.booking-pagination-label {
+  font-size: 0.875rem;
+  font-weight: 800;
+  color: #111827;
+}
+
+.booking-pagination-select {
+  min-width: 88px;
+}
+
+.booking-pagination-button {
+  height: 38px;
+}
+
+.booking-pagination-page {
+  font-weight: 800;
+  color: #111827;
 }
 
 .booking-empty {
@@ -188,16 +248,23 @@
 
 .booking-day {
   background: var(--primary-light);
-  border: 1.5px solid var(--border-color);
+  border: 1.5px solid black;
   border-radius: 12px;
   padding: 1rem;
+  scroll-margin-top: 0.5rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .booking-day-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
+  background: linear-gradient(90deg, var(--primary-light), var(--accent-light));
+  padding-top: 0.25rem;
   padding-bottom: 0.75rem;
   border-bottom: 1px solid var(--border-color);
   margin-bottom: 0.75rem;
@@ -222,13 +289,14 @@
 
 .booking-slot {
   background: #ffffff;
-  border: 1px solid var(--border-color);
+  border: 1px solid black;
   border-radius: 12px;
   padding: 0.85rem 0.9rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .booking-slot-time-main {
@@ -241,6 +309,36 @@
   font-size: 0.875rem;
   color: #4b5563;
   font-weight: 600;
+}
+
+/* Confirm dialog content */
+.booking-confirm-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  border-radius: 12px;
+  background: rgba(17, 24, 39, 0.04);
+  border: 1px solid rgba(17, 24, 39, 0.14);
+}
+
+.booking-confirm-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.booking-confirm-label {
+  font-weight: 800;
+  color: #111827;
+  font-size: 0.9rem;
+}
+
+.booking-confirm-value {
+  font-weight: 700;
+  color: #111827;
+  text-align: right;
 }
 
 .slot-book-button {
@@ -316,5 +414,3 @@
 .booking-toast-close:hover {
   background: rgba(17, 24, 39, 0.14);
 }
-
-

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import type { ReactNode } from "react";
+import "./confirmDialog.css";
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmText,
+  cancelText,
+  confirmDanger,
+  loading,
+  onConfirm,
+  onCancel,
+  children,
+}: {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmDanger?: boolean;
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  children?: ReactNode;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    // Small “real app” things:
+    // - ESC closes the dialog
+    // - clicking the overlay closes it
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return createPortal(
+    // We portal to <body> so it always sits on top (even if you open it from inside another modal).
+    <div className="confirm-overlay" role="presentation" onMouseDown={onCancel}>
+      <div
+        className="confirm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onMouseDown={e => e.stopPropagation()}
+      >
+        <div className="confirm-header">
+          <div className="confirm-title">{title}</div>
+          <button className="confirm-close" type="button" onClick={onCancel} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <div className="confirm-body">
+          {description ? <div className="confirm-description">{description}</div> : null}
+          {children}
+        </div>
+
+        <div className="confirm-footer">
+          <button className="confirm-button secondary" type="button" onClick={onCancel} disabled={!!loading}>
+            {cancelText ?? "Cancel"}
+          </button>
+          <button
+            className={`confirm-button ${confirmDanger ? "danger" : "primary"}`}
+            type="button"
+            onClick={onConfirm}
+            disabled={!!loading}
+          >
+            {/* One button for confirm. When loading, we lock everything so no double-clicks. */}
+            {loading ? "Processing..." : confirmText ?? "Confirm"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+

--- a/frontend/src/components/ui/Icons.tsx
+++ b/frontend/src/components/ui/Icons.tsx
@@ -1,0 +1,144 @@
+import type { ReactNode } from "react";
+
+type IconProps = {
+  className?: string;
+  title?: string;
+};
+
+function SvgIcon({
+  children,
+  className,
+  title,
+}: IconProps & {
+  children: ReactNode;
+}) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      role="img"
+      aria-label={title}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {title ? <title>{title}</title> : null}
+      {children}
+    </svg>
+  );
+}
+
+export function CalendarIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Calendar"}>
+      <rect x="3.5" y="5.5" width="17" height="15" rx="2" />
+      <path d="M7 3.5v4" />
+      <path d="M17 3.5v4" />
+      <path d="M3.5 9h17" />
+    </SvgIcon>
+  );
+}
+
+export function CheckCircleIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Completed"}>
+      <path d="M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z" />
+      <path d="m8 12 2.5 2.5L16 9" />
+    </SvgIcon>
+  );
+}
+
+export function UsersIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Users"}>
+      <path d="M16 11a4 4 0 1 0-8 0" />
+      <path d="M12 13c-4 0-7 2-7 5v1.5h14V18c0-3-3-5-7-5Z" />
+      <path d="M12 3.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7Z" />
+    </SvgIcon>
+  );
+}
+
+export function ClipboardIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Clipboard"}>
+      <rect x="7" y="4.5" width="10" height="16" rx="2" />
+      <path d="M9 4.5V3.5h6v1" />
+      <path d="M10 9h4" />
+      <path d="M10 12h4" />
+      <path d="M10 15h4" />
+    </SvgIcon>
+  );
+}
+
+export function ClockIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Clock"}>
+      <path d="M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z" />
+      <path d="M12 7v6l3 2" />
+    </SvgIcon>
+  );
+}
+
+export function ChartBarIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Chart"}>
+      <path d="M4 19.5V4.5" />
+      <path d="M4 19.5h16" />
+      <path d="M8 17v-6" />
+      <path d="M12 17V8" />
+      <path d="M16 17v-3" />
+    </SvgIcon>
+  );
+}
+
+export function CogIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Settings"}>
+      <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
+      <path d="M19.4 15a8 8 0 0 0 .1-1l2-1.2-2-3.4-2.3.6a7.9 7.9 0 0 0-1.7-1L15.1 6h-6l-.4 2.9a7.9 7.9 0 0 0-1.7 1l-2.3-.6-2 3.4 2 1.2a8 8 0 0 0 .1 1 8 8 0 0 0-.1 1l-2 1.2 2 3.4 2.3-.6a7.9 7.9 0 0 0 1.7 1l.4 2.9h6l.4-2.9a7.9 7.9 0 0 0 1.7-1l2.3.6 2-3.4-2-1.2a8 8 0 0 0-.1-1Z" />
+    </SvgIcon>
+  );
+}
+
+export function PlusIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Add"}>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </SvgIcon>
+  );
+}
+
+export function PillIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Prescription"}>
+      <path d="M14.5 4.5a4.5 4.5 0 0 1 0 9l-6.5 6.5a4 4 0 1 1-5.7-5.7L8.8 7.8a4.5 4.5 0 0 1 5.7-3.3Z" />
+      <path d="M8.8 7.8 16.2 15.2" />
+    </SvgIcon>
+  );
+}
+
+export function FileIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "File"}>
+      <path d="M14 3.5H7a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8.5Z" />
+      <path d="M14 3.5v5h5" />
+      <path d="M8 12h8" />
+      <path d="M8 15h8" />
+    </SvgIcon>
+  );
+}
+
+export function MailIcon(props: IconProps) {
+  return (
+    <SvgIcon {...props} title={props.title ?? "Mail"}>
+      <path d="M4.5 7.5h15v9h-15z" />
+      <path d="m4.5 8 7.5 5 7.5-5" />
+    </SvgIcon>
+  );
+}
+
+

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import "../../index.css";
+import "./modal.css";
+
+export default function Modal({
+  open,
+  title,
+  onClose,
+  children,
+}: {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-overlay" role="presentation" onMouseDown={onClose}>
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onMouseDown={e => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <div className="modal-title">{title}</div>
+          <button className="modal-close" type="button" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="modal-body">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+

--- a/frontend/src/components/ui/confirmDialog.css
+++ b/frontend/src/components/ui/confirmDialog.css
@@ -1,0 +1,126 @@
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(17, 24, 39, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  overscroll-behavior: contain;
+}
+
+.confirm-dialog {
+  width: min(560px, 100%);
+  max-height: min(80vh, 720px);
+  overflow: hidden;
+  background-color: var(--surface);
+  border-radius: 14px;
+  border: 1px solid rgba(17, 24, 39, 0.16);
+  box-shadow: var(--shadow-lg);
+}
+
+.confirm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.95rem 1.1rem;
+  border-bottom: 1px solid var(--border-color);
+  background: linear-gradient(90deg, var(--primary-soft), var(--accent-soft));
+}
+
+.confirm-title {
+  font-weight: 900;
+  color: #111827;
+  font-size: 1.05rem;
+}
+
+.confirm-close {
+  height: 36px;
+  width: 36px;
+  border-radius: 10px;
+  border: 1px solid rgba(17, 24, 39, 0.16);
+  background: rgba(17, 24, 39, 0.08);
+  color: #111827;
+  cursor: pointer;
+  font-size: 1.25rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.confirm-close:hover {
+  background: rgba(17, 24, 39, 0.14);
+}
+
+.confirm-body {
+  padding: 1.1rem;
+  overflow: auto;
+  max-height: calc(80vh - 120px);
+}
+
+.confirm-description {
+  color: #4b5563;
+  font-weight: 600;
+  margin-bottom: 0.85rem;
+  line-height: 1.5;
+}
+
+.confirm-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0.95rem 1.1rem;
+  border-top: 1px solid var(--border-color);
+  background: rgba(17, 24, 39, 0.04);
+}
+
+.confirm-button {
+  height: 42px;
+  border-radius: 10px;
+  padding: 0 1rem;
+  border: 1.5px solid rgba(17, 24, 39, 0.18);
+  background: rgba(17, 24, 39, 0.08);
+  color: #111827;
+  font-weight: 900;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  outline: none;
+}
+
+.confirm-button:hover:not(:disabled) {
+  background: rgba(17, 24, 39, 0.14);
+}
+
+.confirm-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.confirm-button.secondary {
+  background: #ffffff;
+  border-color: rgba(17, 24, 39, 0.18);
+}
+
+.confirm-button.secondary:hover:not(:disabled) {
+  background: rgba(17, 24, 39, 0.06);
+}
+
+.confirm-button.primary {
+  background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+  border-color: rgba(17, 24, 39, 0.24);
+  color: #111827;
+}
+
+.confirm-button.primary:hover:not(:disabled) {
+  filter: brightness(0.98);
+}
+
+.confirm-button.danger {
+  background: var(--danger-color);
+  border-color: rgba(17, 24, 39, 0.24);
+  color: #111827;
+}
+
+

--- a/frontend/src/components/ui/modal.css
+++ b/frontend/src/components/ui/modal.css
@@ -1,0 +1,66 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  z-index: 50;
+  overscroll-behavior: contain;
+}
+
+.modal {
+  width: min(920px, 100%);
+  max-height: min(85vh, 900px);
+  overflow: hidden;
+  background: var(--surface);
+  border-radius: 14px;
+  border: 1px solid rgba(17, 24, 39, 0.14);
+  box-shadow: var(--shadow-lg);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  background: white;
+}
+
+.modal-title {
+  font-weight: 900;
+  color: #111827;
+  font-size: 1.05rem;
+}
+
+.modal-close {
+  height: 36px;
+  width: 36px;
+  border-radius: 10px;
+  border: 1px solid rgba(17, 24, 39, 0.16);
+  background: rgba(17, 24, 39, 0.08);
+  color: #111827;
+  cursor: pointer;
+  font-size: 1.25rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  background: rgba(17, 24, 39, 0.14);
+}
+
+.modal-body {
+  padding: 1.25rem;
+  max-height: calc(95vh - 64px);
+  background-color: white;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,6 +9,13 @@
   --primary-color: #0066cc; /* Professional healthcare blue */
   --primary-hover: #0052a3; /* Darker blue on hover */
   --primary-light: #e6f2ff; /* Very light blue for backgrounds */
+  /* Secondary healthcare accent (teal) */
+  --accent-color: #0f766e;
+  --accent-hover: #115e59;
+  --accent-light: #ccfbf1;
+  --accent-soft: rgba(15, 118, 110, 0.12);
+  --primary-soft: rgba(0, 102, 204, 0.12);
+
   --secondary-color: #6b7280;
   --success-color: #059669;
   --danger-color: #dc2626;
@@ -16,6 +23,7 @@
   --background: #ffffff; /* Pure white background */
   --background-alt: #f8fafc; /* Slight gray for contrast */
   --surface: #ffffff; /* Pure white for cards */
+  --surface-tint: #fbfdff; /* slight tint to avoid flat pure white everywhere */
   --text-primary: #111827; /* Almost black for maximum contrast */
   --text-secondary: #4b5563; /* Dark gray for secondary text */
   --border-color: #e5e7eb; /* Light gray borders */

--- a/frontend/src/layout/AppLayout.tsx
+++ b/frontend/src/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, Link, useLocation } from "react-router-dom";
 import { useAuth, formatRole } from "../auth/AuthContext";
+import { ChartBarIcon, CogIcon } from "../components/ui/Icons";
 import "./layout.css";
 
 export default function AppLayout() {
@@ -19,14 +20,18 @@ export default function AppLayout() {
             to="/dashboard"
             className={`nav-link ${isActive("/dashboard") ? "active" : ""}`}
           >
-            <span className="nav-icon">📊</span>
+            <span className="nav-icon">
+              <ChartBarIcon />
+            </span>
             Dashboard
           </Link>
           <Link
             to="/delete-account"
             className={`nav-link ${isActive("/delete-account") ? "active" : ""}`}
           >
-            <span className="nav-icon">⚙️</span>
+            <span className="nav-icon">
+              <CogIcon />
+            </span>
             Account Settings
           </Link>
         </nav>

--- a/frontend/src/layout/layout.css
+++ b/frontend/src/layout/layout.css
@@ -58,6 +58,15 @@
 
 .nav-icon {
   font-size: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav-icon svg {
+  width: 18px;
+  height: 18px;
+  display: block;
 }
 
 .sidebar-footer {

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -27,12 +27,21 @@
   gap: 2rem;
 }
 
+.dashboard-alert {
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  background: linear-gradient(90deg, var(--primary-soft), var(--accent-soft));
+  border: 1.5px solid rgba(17, 24, 39, 0.18);
+  color: #111827;
+  font-weight: 800;
+}
+
 .dashboard-section {
-  background: #ffffff;
+  background: var(--surface-tint);
   border-radius: 12px;
   padding: 1.5rem;
   box-shadow: var(--shadow-md);
-  border: 1px solid var(--border-color);
+  border: 1px solid black;
   outline: none;
 }
 
@@ -126,7 +135,7 @@
   border-radius: 12px;
   padding: 1.5rem;
   box-shadow: var(--shadow-md);
-  border: 1px solid var(--border-color);
+  border: 1px solid black;
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -146,9 +155,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--primary-light);
+  background: linear-gradient(135deg, var(--primary-light), var(--accent-light));
   border-radius: 12px;
   flex-shrink: 0;
+  color: var(--primary-color);
+}
+
+.stat-icon svg {
+  width: 30px;
+  height: 30px;
+  display: block;
 }
 
 .stat-content {
@@ -178,7 +194,7 @@
 
 .action-button {
   background: var(--primary-light);
-  border: 1.5px solid var(--border-color);
+  border: 1.5px solid rgb(37, 37, 37);
   border-radius: 10px;
   padding: 1.25rem;
   display: flex;
@@ -207,6 +223,15 @@
 
 .action-icon {
   font-size: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.action-icon svg {
+  width: 26px;
+  height: 26px;
+  display: block;
 }
 
 /* Appointments List */
@@ -352,6 +377,13 @@
   border-radius: 8px;
   border: 1px solid var(--border-color);
   flex-shrink: 0;
+  color: var(--primary-color);
+}
+
+.activity-icon svg {
+  width: 22px;
+  height: 22px;
+  display: block;
 }
 
 .activity-content {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,20 @@
+import { useEffect, useState } from "react";
 import { useAuth, formatRole, normalizeRoleId } from "../auth/AuthContext";
 import PatientAppointmentBooking from "../components/appointments/PatientAppointmentBooking";
+import Modal from "../components/ui/Modal";
+import {
+  CalendarIcon,
+  ChartBarIcon,
+  CheckCircleIcon,
+  ClipboardIcon,
+  ClockIcon,
+  CogIcon,
+  FileIcon,
+  MailIcon,
+  PillIcon,
+  PlusIcon,
+  UsersIcon,
+} from "../components/ui/Icons";
 import "./Dashboard.css";
 
 export default function Dashboard() {
@@ -11,42 +26,62 @@ export default function Dashboard() {
   const roleId = normalizeRoleId(user.role);
   const isPatient = roleId === 0 || roleText === "Patient";
   const isCaregiver = roleId === 1 || roleText === "Caregiver";
+  const [bookingOpen, setBookingOpen] = useState(false);
+  const [dashboardToast, setDashboardToast] = useState<string>("");
+
+  useEffect(() => {
+    if (!dashboardToast) return;
+    const t = window.setTimeout(() => setDashboardToast(""), 4000);
+    return () => window.clearTimeout(t);
+  }, [dashboardToast]);
+
+  const displayName =
+    user.firstName && user.lastName ? `${user.firstName} ${user.lastName}` : user.email;
 
   return (
     <div className="dashboard">
       <div className="dashboard-header">
         <h1>Dashboard</h1>
-        <p className="welcome-text">Welcome back, {user.email}!</p>
+        <p className="welcome-text">Welcome back, {displayName}!</p>
       </div>
 
       <div className="dashboard-content">
+        {dashboardToast && <div className="dashboard-alert">{dashboardToast}</div>}
         {/* Stats Overview */}
         <div className="stats-grid">
           {isPatient && (
             <>
               <div className="stat-card">
-                <div className="stat-icon">📅</div>
+                <div className="stat-icon">
+                  <CalendarIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">3</div>
                   <div className="stat-label">Upcoming Appointments</div>
                 </div>
               </div>
               <div className="stat-card">
-                <div className="stat-icon">✅</div>
+                <div className="stat-icon">
+                  <CheckCircleIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">12</div>
                   <div className="stat-label">Completed Visits</div>
                 </div>
               </div>
               <div className="stat-card">
-                <div className="stat-icon">👨‍⚕️</div>
+                <div className="stat-icon">
+                  <UsersIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">2</div>
                   <div className="stat-label">Active Providers</div>
                 </div>
               </div>
               <div className="stat-card">
-                <div className="stat-icon">📋</div>
+                <div className="stat-icon">
+                  <ClipboardIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">5</div>
                   <div className="stat-label">Pending Requests</div>
@@ -58,28 +93,36 @@ export default function Dashboard() {
           {isCaregiver && (
             <>
               <div className="stat-card">
-                <div className="stat-icon">📅</div>
+                <div className="stat-icon">
+                  <CalendarIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">8</div>
                   <div className="stat-label">Today's Appointments</div>
                 </div>
               </div>
               <div className="stat-card">
-                <div className="stat-icon">⏰</div>
+                <div className="stat-icon">
+                  <ClockIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">24</div>
                   <div className="stat-label">This Week</div>
                 </div>
               </div>
               <div className="stat-card">
-                <div className="stat-icon">👥</div>
+                <div className="stat-icon">
+                  <UsersIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">45</div>
                   <div className="stat-label">Total Patients</div>
                 </div>
               </div>
               <div className="stat-card">
-                <div className="stat-icon">📊</div>
+                <div className="stat-icon">
+                  <ChartBarIcon />
+                </div>
                 <div className="stat-content">
                   <div className="stat-value">92%</div>
                   <div className="stat-label">Availability</div>
@@ -95,20 +138,28 @@ export default function Dashboard() {
           <div className="actions-grid">
             {isPatient && (
               <>
-                <button className="action-button" type="button">
-                  <span className="action-icon">➕</span>
+                <button className="action-button" type="button" onClick={() => setBookingOpen(true)}>
+                  <span className="action-icon">
+                    <PlusIcon />
+                  </span>
                   <span>Book New Appointment</span>
                 </button>
                 <button className="action-button" type="button">
-                  <span className="action-icon">📋</span>
+                  <span className="action-icon">
+                    <ClipboardIcon />
+                  </span>
                   <span>View Appointments</span>
                 </button>
                 <button className="action-button" type="button">
-                  <span className="action-icon">💊</span>
+                  <span className="action-icon">
+                    <PillIcon />
+                  </span>
                   <span>My Prescriptions</span>
                 </button>
                 <button className="action-button" type="button">
-                  <span className="action-icon">📄</span>
+                  <span className="action-icon">
+                    <FileIcon />
+                  </span>
                   <span>Medical Records</span>
                 </button>
               </>
@@ -117,19 +168,27 @@ export default function Dashboard() {
             {isCaregiver && (
               <>
                 <button className="action-button" type="button">
-                  <span className="action-icon">📅</span>
+                  <span className="action-icon">
+                    <CalendarIcon />
+                  </span>
                   <span>Set Availability</span>
                 </button>
                 <button className="action-button" type="button">
-                  <span className="action-icon">👥</span>
+                  <span className="action-icon">
+                    <UsersIcon />
+                  </span>
                   <span>View Patients</span>
                 </button>
                 <button className="action-button" type="button">
-                  <span className="action-icon">📊</span>
+                  <span className="action-icon">
+                    <ChartBarIcon />
+                  </span>
                   <span>View Schedule</span>
                 </button>
                 <button className="action-button" type="button">
-                  <span className="action-icon">⚙️</span>
+                  <span className="action-icon">
+                    <CogIcon />
+                  </span>
                   <span>Manage Profile</span>
                 </button>
               </>
@@ -138,9 +197,12 @@ export default function Dashboard() {
         </div>
 
         {isPatient && (
-          <div className="dashboard-section">
-            <PatientAppointmentBooking />
-          </div>
+          <Modal open={bookingOpen} title="Book appointment" onClose={() => setBookingOpen(false)}>
+            <PatientAppointmentBooking
+              onBooked={() => setDashboardToast("Appointment booked successfully.")}
+              onRequestClose={() => setBookingOpen(false)}
+            />
+          </Modal>
         )}
 
         {/* Upcoming Appointments / Today's Schedule */}
@@ -261,28 +323,36 @@ export default function Dashboard() {
           <h2>{isPatient ? "Recent Activity" : "Notifications"}</h2>
           <div className="activity-list">
             <div className="activity-item">
-              <div className="activity-icon">📧</div>
+              <div className="activity-icon">
+                <MailIcon />
+              </div>
               <div className="activity-content">
                 <div className="activity-title">Appointment Reminder</div>
                 <div className="activity-time">2 hours ago</div>
               </div>
             </div>
             <div className="activity-item">
-              <div className="activity-icon">✅</div>
+              <div className="activity-icon">
+                <CheckCircleIcon />
+              </div>
               <div className="activity-content">
                 <div className="activity-title">Appointment Confirmed</div>
                 <div className="activity-time">Yesterday</div>
               </div>
             </div>
             <div className="activity-item">
-              <div className="activity-icon">📄</div>
+              <div className="activity-icon">
+                <FileIcon />
+              </div>
               <div className="activity-content">
                 <div className="activity-title">New Test Results Available</div>
                 <div className="activity-time">2 days ago</div>
               </div>
             </div>
             <div className="activity-item">
-              <div className="activity-icon">💊</div>
+              <div className="activity-icon">
+                <PillIcon />
+              </div>
               <div className="activity-content">
                 <div className="activity-title">Prescription Renewal</div>
                 <div className="activity-time">3 days ago</div>

--- a/frontend/src/pages/DeleteAccount.css
+++ b/frontend/src/pages/DeleteAccount.css
@@ -179,13 +179,13 @@
   width: 20px;
   left: 4px;
   bottom: 4px;
-  background-color: white;
+  background-color: rgb(255, 255, 255);
   transition: 0.3s;
   border-radius: 50%;
 }
 
 .toggle-switch input:checked + .toggle-slider {
-  background-color: var(--primary-color);
+  background-color: rgb(145, 247, 145);
 }
 
 .toggle-switch input:checked + .toggle-slider:before {

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -5,6 +5,8 @@ import AuthLayout from "../components/AuthLayout";
 
 export default function Register() {
   const [email, setEmail] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [role, setRole] = useState<"patient" | "caregiver">("patient");
@@ -28,13 +30,18 @@ export default function Register() {
       return;
     }
 
+    if (!firstName.trim() || !lastName.trim()) {
+      setError("Please enter your first and last name");
+      return;
+    }
+
     setLoading(true);
 
     try {
       if (role === "patient") {
-        await registerPatient({ email, password });
+        await registerPatient({ email, password, firstName: firstName.trim(), lastName: lastName.trim() });
       } else {
-        await registerCaregiver({ email, password });
+        await registerCaregiver({ email, password, firstName: firstName.trim(), lastName: lastName.trim() });
       }
       setSuccess(true);
       setTimeout(() => {
@@ -90,11 +97,39 @@ export default function Register() {
         </div>
 
         <div className="form-group">
+          <label htmlFor="firstName">First name</label>
+          <input
+            id="firstName"
+            type="text"
+            placeholder="Enter your first name"
+            value={firstName}
+            onChange={e => setFirstName(e.target.value)}
+            required
+            disabled={loading}
+            autoComplete="given-name"
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="lastName">Last name</label>
+          <input
+            id="lastName"
+            type="text"
+            placeholder="Enter your last name"
+            value={lastName}
+            onChange={e => setLastName(e.target.value)}
+            required
+            disabled={loading}
+            autoComplete="family-name"
+          />
+        </div>
+
+        <div className="form-group">
           <label htmlFor="password">Password</label>
           <input
             id="password"
             type="password"
-            placeholder="Create a password (min. 6 characters)"
+            placeholder="Create a password (min. 8 characters)"
             value={password}
             onChange={e => setPassword(e.target.value)}
             required


### PR DESCRIPTION
### Summary

This PR introduces a complete patient-side appointment booking flow. Patients can now browse available appointment slots, filter them, and book appointments through a dedicated UI instead of relying on raw IDs or manual API interaction.

### Patient booking interface

1. New booking UI that allows patients to:
2. View available appointment slots
3. See caregiver names alongside times
4. Book appointments directly from the UI
5. Booking happens inside a modal, keeping patients in context

🧭 Availability discovery (not ID-driven)

Patients no longer need to know caregiver IDs
Availability is fetched and presented in a human-readable way
Caregivers are selectable by name, with an option to view all caregivers

---

### Filtering & organization
Appointment slots are:
- Sorted by start time

Optional filters:
- Caregiver
- Date
- Pagination support for large numbers of slots

---

### Correct time handling

- All appointment times are displayed in the patient’s local timezone
- Past availability is automatically excluded
- Slot duration is shown for clarity
- 

---

### Booking flow

Confirmation dialog before booking
Optimistic UI update after booking
Automatic refresh of availability to stay in sync with backend state
Clear success and error feedback

this closes issue #19 